### PR TITLE
Quit when wmenu is out of focus

### DIFF
--- a/wmenu/MainForm.Designer.cs
+++ b/wmenu/MainForm.Designer.cs
@@ -66,6 +66,7 @@
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.WindowsDefaultBounds;
             this.TopMost = true;
+            this.Deactivate += new System.EventHandler(this.MainForm_Deactivate);
             this.Load += new System.EventHandler(this.MainForm_Load);
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/wmenu/MainForm.cs
+++ b/wmenu/MainForm.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Win32;
-using System.ComponentModel;
 using System.Data;
 using System.Drawing;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.IO;
 using System.Diagnostics;
 
 namespace wmenu
@@ -121,6 +118,11 @@ namespace wmenu
         {
             if (e.KeyCode == Keys.Escape) this.Close();
             if (e.KeyCode == Keys.Enter) RunProgram();
+        }
+
+        private void MainForm_Deactivate(object sender, EventArgs e)
+        {
+            this.Close();
         }
     }
 }


### PR DESCRIPTION
If the user clicks elsewhere, wmenu should quit itself.